### PR TITLE
Update MacOS fluidsynth library alias

### DIFF
--- a/src/sound/music_fluidsynth_mididevice.cpp
+++ b/src/sound/music_fluidsynth_mididevice.cpp
@@ -60,7 +60,7 @@
 #include <dlfcn.h>
 
 #ifdef __APPLE__
-#define FLUIDSYNTHLIB1	"libfluidsynth.1.dylib"
+#define FLUIDSYNTHLIB1	"libfluidsynth.dylib"
 #else // !__APPLE__
 #define FLUIDSYNTHLIB1	"libfluidsynth.so.1"
 #endif // __APPLE__


### PR DESCRIPTION
Change from the old default alias "libfluidsynth.1.dylib" to the currently "libfluidynth.dylib" alias